### PR TITLE
Add a table of contents to README.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 ### Docs
 - Add screenshot to README.md
+- Add a table of contents to README.md
 
 ### Maintenance
 - Tweak Travis config (add `os` and `dist` specifications, remove `gem install bundler -v 2.1.4`,

--- a/README.md
+++ b/README.md
@@ -4,7 +4,20 @@ Print the execution time of your slowest RSpec examples.
 
 ![rspec_performance_summary screenshot](https://user-images.githubusercontent.com/8197963/85248189-f61a2980-b404-11ea-8eef-503b43808d63.png)
 
-## Installation
+<!--ts-->
+   * [RspecPerformanceSummary](#rspecperformancesummary)
+   * [Installation](#installation)
+   * [Usage](#usage)
+   * [Credit](#credit)
+   * [Development](#development)
+   * [For maintainers](#for-maintainers)
+   * [License](#license)
+
+<!-- Added by: david, at: Sun Jun 21 21:53:07 PDT 2020 -->
+
+<!--te-->
+
+# Installation
 
 Add the gem to the `test` group of your application's `Gemfile`. Because the gem is not released via
 RubyGems, you will need to install it from GitHub.
@@ -25,12 +38,12 @@ Finally, add this to the `spec/spec_helper.rb` file in your project:
 require 'rspec_performance_summary'
 ```
 
-## Usage
+# Usage
 
 Just run one or more of your RSpec tests! The performance summary should be printed automatically
 after the tests have completed.
 
-## Credit
+# Credit
 
 I borrowed this code for the performance logging from
 https://coderwall.com/p/l3nl_w/measure-spec-execution-time .
@@ -38,17 +51,26 @@ https://coderwall.com/p/l3nl_w/measure-spec-execution-time .
 I borrowed the general code approach for plugging into RSpec from a gem from
 [rspec-retry](https://github.com/NoRedInk/rspec-retry).
 
-## Development
+# Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run
-the tests. You can also run `bin/console` for an interactive prompt that will allow you to
+After checking out the repo, run `bundle install` to install dependencies. Then, run `bin/rspec` to
+run the tests. You can also run `bin/console` for an interactive prompt that will allow you to
 experiment.
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new
-version, update the version number in `version.rb`, and then run `bin/release`, which will create a
-git tag for the version and push git commits and tags.
+To install this gem onto your local machine, run `bundle exec rake install`.
 
-## License
+# For maintainers
+
+To release a new version:
+1. check out the `master` branch
+2. update `CHANGELOG.md`
+3. update the version number in `version.rb`
+4. `bundle install` (which will update `Gemfile.lock`)
+5. commit the changes with a message like `Prepare to release v0.1.1`
+6. push the changes to `origin/master` (GitHub) via `git push`
+7. run `bin/release`, which will create a git tag for the version and push git commits and tags
+
+# License
 
 The gem is available as open source under the terms of the [MIT
 License](https://opensource.org/licenses/MIT).


### PR DESCRIPTION
(plus some other tweaks to README.md)

Thanks, https://github.com/ekalinin/github-markdown-toc/ !

Command used:
```
gh-md-toc --insert README.md ; rm $(ls README.md.*)
```

(this removes the backup files that `gh-md-toc` creates)