### PR TITLE
Remove explicit `git push` from release instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+### Docs
+- Remove explicit `git push` from release instructions
+
 ## v0.1.3 (2020-06-21)
 ### Docs
 - Add screenshot to README.md

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rspec_performance_summary (0.1.3)
+    rspec_performance_summary (0.1.3.alpha)
       rspec-core (~> 3.0)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -74,8 +74,7 @@ To release a new version:
 3. update the version number in `version.rb`
 4. `bundle install` (which will update `Gemfile.lock`)
 5. commit the changes with a message like `Prepare to release v0.1.1`
-6. push the changes to `origin/master` (GitHub) via `git push`
-7. run `bin/release`, which will create a git tag for the version and push git commits and tags
+6. run `bin/release`, which will create a git tag for the version and push git commits and tags
 
 # License
 

--- a/lib/rspec_performance_summary/version.rb
+++ b/lib/rspec_performance_summary/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RspecPerformanceSummary
-  VERSION = '0.1.3'
+  VERSION = '0.1.3.alpha'
 end


### PR DESCRIPTION
`git push` will be done automatically by the `bundle exec rake release` command in `bin/release`.