### PR TITLE
Have dependabot update gems monthly (rather than weekly)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
 - package-ecosystem: bundler
   directory: "/"
   schedule:
-    interval: weekly
+    interval: monthly
     time: "13:52"
     timezone: America/Los_Angeles
   open-pull-requests-limit: 20


### PR DESCRIPTION
I don't use this gem anywhere right now, and I don't really care about its dependencies being totally up to date.