### PR TITLE
Change references to "master" branch to "main"

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -4,7 +4,7 @@ name: Run Rspec Tests
 on:
   pull_request:
     branches:
-    - master
+    - main
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- Rename primary branch from `master` to `main`
 
 ## v1.0.0 (2024-03-08)
 - Bump required minimum Ruby version from 3.2 to 3.3.0

--- a/rspec_performance_summary.gemspec
+++ b/rspec_performance_summary.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = spec.homepage
   spec.metadata['changelog_uri'] =
-    'https://github.com/davidrunger/rspec_performance_summary/blob/master/CHANGELOG.md'
+    'https://github.com/davidrunger/rspec_performance_summary/blob/main/CHANGELOG.md'
 
   spec.files =
     Dir.chdir(File.expand_path(__dir__)) do


### PR DESCRIPTION
I have renamed the "master" branch in GitHub to "main", so we need to update these references to reflect that change.